### PR TITLE
feat: brotli compression

### DIFF
--- a/src/Pango.Tool/Commands/ComponentRegisterCreation.cs
+++ b/src/Pango.Tool/Commands/ComponentRegisterCreation.cs
@@ -29,19 +29,29 @@ public sealed class ComponentRegisterCreation : AsyncCommand<ComponentRegisterCr
     )
     {
         var registryManager = new RegistryManager();
-
-        var components = settings
-            .ComponentsSource.Select(src => new CreateComponentMetadataInput(src))
-            .Select(registryManager.CreateComponentMetadata)
-            .Where(result => result.IsOk())
-            .Select(result => result.Expect());
-
         var outputDir = new DirectoryInfo(settings.Output);
         if (!outputDir.Exists)
             outputDir.Create();
 
-        foreach (var component in components)
+        foreach (var source in settings.ComponentsSource)
         {
+            var componentBaseSource = string.Join(
+                Path.VolumeSeparatorChar,
+                source.Split(Path.VolumeSeparatorChar).SkipLast(1)
+            );
+
+            var componentResult = await registryManager
+                .CreateComponentMetadata(new CreateComponentMetadataInput(source))
+                .AndThen(component =>
+                    registryManager.PackComponent(
+                        new PackComponentInput(component, componentBaseSource, outputDir.FullName)
+                    )
+                );
+
+            var component = componentResult
+                .InspectErr(err => AnsiConsole.MarkupLineInterpolated($"[bold red]Fail: {err}[/]."))
+                .Expect();
+
             var metadataFileName = Path.ChangeExtension(component.Name, ".json");
             var metadataFilePath = Path.Combine(outputDir.FullName, metadataFileName);
             await using var metadataFile = File.Create(metadataFilePath);

--- a/src/Pango.Tool/Commands/ComponentRegisterCreation.cs
+++ b/src/Pango.Tool/Commands/ComponentRegisterCreation.cs
@@ -1,27 +1,17 @@
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Text.Json;
-
-using Spectre.Console;
-using Spectre.Console.Cli;
-
 using Pango.Abstractions;
 using Pango.Services.RegistryManager;
+using Spectre.Console;
+using Spectre.Console.Cli;
 
 namespace Pango.Commands;
 
 public sealed class ComponentRegisterCreation : AsyncCommand<ComponentRegisterCreation.Settings>
 {
-    private static readonly TextInfo ti = CultureInfo.CurrentCulture.TextInfo;
-
     public sealed class Settings : CommandSettings
     {
-        [NotNull]
-        [Description("URI to upload with your components.")]
-        [CommandOption("--registry-uri")]
-        public required string RegistryUri { get; set; }
-
         [NotNull]
         [Description("Folder with multiple components or single component.")]
         [CommandArgument(0, "<ARGUMENT>")]
@@ -33,13 +23,15 @@ public sealed class ComponentRegisterCreation : AsyncCommand<ComponentRegisterCr
         public required string Output { get; set; }
     }
 
-    public override async Task<int> ExecuteAsync([NotNull] CommandContext context, [NotNull] Settings settings)
+    public override async Task<int> ExecuteAsync(
+        [NotNull] CommandContext context,
+        [NotNull] Settings settings
+    )
     {
-        var registryUri = new Uri(settings.RegistryUri);
-        var registryManager = new RegistryManager(new(registryUri));
+        var registryManager = new RegistryManager();
 
-        var components = settings.ComponentsSource
-            .Select(src => new CreateComponentMetadataInput(src))
+        var components = settings
+            .ComponentsSource.Select(src => new CreateComponentMetadataInput(src))
             .Select(registryManager.CreateComponentMetadata)
             .Where(result => result.IsOk())
             .Select(result => result.Expect());
@@ -98,7 +90,7 @@ public sealed class ComponentRegisterCreation : AsyncCommand<ComponentRegisterCr
 
         /*         if(path is SingleComponent searchAllComponents)
                 {
-                    AnsiConsole.WriteLine("Single: " + searchAllComponents.Path);  
+                    AnsiConsole.WriteLine("Single: " + searchAllComponents.Path);
                 } */
 
         // if(settings.AllComponents ?? false)
@@ -110,7 +102,7 @@ public sealed class ComponentRegisterCreation : AsyncCommand<ComponentRegisterCr
         //         .PageSize(10)
         //         .InstructionsText(
         //             "[grey](If you want to register all components, select none and press enter)[/]\n\n" +
-        //             "[grey](Press [blue]<space>[/] to toggle a fruit, " + 
+        //             "[grey](Press [blue]<space>[/] to toggle a fruit, " +
         //             "[green]<enter>[/] to accept)[/]\n")
         //         .AddChoices([..componentsJson.Select(c => ti.ToTitleCase(c.Name))]));
 
@@ -118,7 +110,7 @@ public sealed class ComponentRegisterCreation : AsyncCommand<ComponentRegisterCr
         //     {
         //         AnsiConsole.WriteLine("Register all components from json: " + JsonSerializer.Serialize(componentsJson));
         //     }
-        //     else 
+        //     else
         //     {
         //         foreach (string component in components)
         //         {
@@ -147,10 +139,6 @@ public sealed class ComponentRegisterCreation : AsyncCommand<ComponentRegisterCr
                     return ValidationResult.Error($"You must pass a source (-s|--src) to find the component(s) to register | Example: `registry-create-metadata path.to.register/ -s ./UI/*`\n");
                 } */
 
-        if (string.IsNullOrEmpty(settings.RegistryUri))
-        {
-            return ValidationResult.Error($"You must pass a URI to register component(s) | Example: `registry-create-metadata path.to.register/ -s ./UI/*`\n");
-        }
         return base.Validate(context, settings);
     }
 }

--- a/src/Pango.Tool/Commands/DownloadComponent.cs
+++ b/src/Pango.Tool/Commands/DownloadComponent.cs
@@ -1,12 +1,11 @@
-using Spectre.Console.Cli;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Pango.Abstractions;
 using Pango.Services.RegistryClient;
-using System.Diagnostics.CodeAnalysis;
-using ComponentModel = System.ComponentModel;
-using Spectre.Console;
-using System.Diagnostics;
-using System.Text.Json;
 using Pango.Types;
+using Spectre.Console;
+using Spectre.Console.Cli;
+using ComponentModel = System.ComponentModel;
 
 namespace Pango.Commands;
 
@@ -40,19 +39,28 @@ public sealed class DownloadComponent : AsyncCommand<DownloadComponentSettings>
         [NotNull] DownloadComponentSettings settings
     )
     {
-        AnsiConsole.MarkupLineInterpolated($"[bold grey]Adding Component:[/] [underline]{settings.ComponentName}[/]");
+        AnsiConsole.MarkupLineInterpolated(
+            $"[bold grey]Adding Component:[/] [underline]{settings.ComponentName}[/]"
+        );
 
-        var httpClient = new HttpClient();
-        var foundComponentResult = (await AnsiConsole
-            .Status()
-            .StartAsync("Fetching component metadata...", async ctx =>
-                await Component.ResolveFrom(
-                    httpClient: httpClient,
-                    remoteUri: settings.RegistryUri,
-                    name: settings.ComponentName
+        var httpClient = new HttpClient() { BaseAddress = new Uri(settings.RegistryUri) };
+        var foundComponentResult = (
+            await AnsiConsole
+                .Status()
+                .StartAsync(
+                    "Fetching component metadata...",
+                    async ctx =>
+                        await Component.ResolveFrom(
+                            httpClient: httpClient,
+                            name: settings.ComponentName
+                        )
                 )
-            ))
-            .Inspect(result => AnsiConsole.MarkupLineInterpolated($"[bold grey]Fetch:[/] found {result.Metadata.Files.Length} files for this component."))
+        )
+            .Inspect(result =>
+                AnsiConsole.MarkupLineInterpolated(
+                    $"[bold grey]Fetch:[/] found {result.Metadata.Files.Length} files for this component."
+                )
+            )
             .InspectErr(err => AnsiConsole.MarkupLineInterpolated($"[bold red]Fail: {err}[/]."));
 
         if (foundComponentResult.Ok() is not Some<Component<Resolved>> component)
@@ -60,30 +68,45 @@ public sealed class DownloadComponent : AsyncCommand<DownloadComponentSettings>
 
         await AnsiConsole
             .Status()
-            .StartAsync("Downloading component files...", async ctx =>
-            {
-                await foreach (var item in component.Value.GetComponentStreams(httpClient))
+            .StartAsync(
+                "Downloading component files...",
+                async ctx =>
                 {
-                    var downloadResult = await item
-                        .Inspect(result => ctx.Status($"Download: {result.State.FileName}"))
-                        .InspectErr(err => AnsiConsole.MarkupLineInterpolated($"[bold red]Fail: {err}[/]."))
-                        .AndThen(async item =>
-                            await item.Download(
-                                localBaseComponentPath: settings.Output,
-                                localBaseNamespace: settings.Namespace
+                    await foreach (var item in component.Value.GetComponentStreams(httpClient))
+                    {
+                        var downloadResult = await item.Inspect(result =>
+                                ctx.Status($"Download: {result.State.FileName}")
                             )
-                        );
+                            .InspectErr(err =>
+                                AnsiConsole.MarkupLineInterpolated($"[bold red]Fail: {err}[/].")
+                            )
+                            .AndThen(async item =>
+                                await item.Download(
+                                    localBaseComponentPath: settings.Output,
+                                    localBaseNamespace: settings.Namespace
+                                )
+                            );
 
-                    downloadResult
-                        .Inspect(result => AnsiConsole.MarkupLineInterpolated($"[bold grey]Saved: {result.State.Filepath}[/]"))
-                        .InspectErr(err => AnsiConsole.MarkupLineInterpolated($"[bold red]Fail: {err}[/]."));
+                        downloadResult
+                            .Inspect(result =>
+                                AnsiConsole.MarkupLineInterpolated(
+                                    $"[bold grey]Saved: {result.State.Filepath}[/]"
+                                )
+                            )
+                            .InspectErr(err =>
+                                AnsiConsole.MarkupLineInterpolated($"[bold red]Fail: {err}[/].")
+                            );
+                    }
                 }
-            });
+            );
 
         return 0;
     }
 
-    public override ValidationResult Validate(CommandContext context, DownloadComponentSettings settings)
+    public override ValidationResult Validate(
+        CommandContext context,
+        DownloadComponentSettings settings
+    )
     {
         if (settings.ComponentName is null)
         {
@@ -92,23 +115,30 @@ public sealed class DownloadComponent : AsyncCommand<DownloadComponentSettings>
 
         var loadConfigTask = AnsiConsole
             .Status()
-            .StartAsync("Loading pango configuration file", async ctx =>
-            {
-                var configFileInfo = new FileInfo("./pango-ui.config.json");
-
-                if (!configFileInfo.Exists)
+            .StartAsync(
+                "Loading pango configuration file",
+                async ctx =>
                 {
-                    AnsiConsole.MarkupLine("[grey]No configuration file found, try run [/][underline]pango init[/]");
-                    return;
+                    var configFileInfo = new FileInfo("./pango-ui.config.json");
+
+                    if (!configFileInfo.Exists)
+                    {
+                        AnsiConsole.MarkupLine(
+                            "[grey]No configuration file found, try run [/][underline]pango init[/]"
+                        );
+                        return;
+                    }
+
+                    using var configFileStream = configFileInfo.OpenRead();
+                    var config = await JsonSerializer.DeserializeAsync<LocalConfig>(
+                        configFileStream
+                    );
+
+                    settings.Namespace ??= config.TargetComponentNamespace;
+                    settings.Output ??= config.LocalComponentPath;
+                    settings.RegistryUri ??= config.RegistrySchemaUri;
                 }
-
-                using var configFileStream = configFileInfo.OpenRead();
-                var config = await JsonSerializer.DeserializeAsync<LocalConfig>(configFileStream);
-
-                settings.Namespace ??= config.TargetComponentNamespace;
-                settings.Output ??= config.LocalComponentPath;
-                settings.RegistryUri ??= config.RegistrySchemaUri;
-            });
+            );
 
         loadConfigTask.Wait();
 

--- a/src/Pango/Services/RegistryManager/IRegistryManager.cs
+++ b/src/Pango/Services/RegistryManager/IRegistryManager.cs
@@ -11,7 +11,15 @@ public record struct CreateComponentMetadataInput(
     string LocalComponentPath
 );
 
+public record struct PackComponentInput(
+    ComponentMetadata Metadata,
+    string InputBasePath,
+    string OutputPath
+);
+
 public interface IRegistryManager
 {
     Result<ComponentMetadata, IRegistryError> CreateComponentMetadata(CreateComponentMetadataInput metadataInput);
+
+    Task<Result<ComponentMetadata, IRegistryError>> PackComponent(PackComponentInput packInput);
 }

--- a/src/Pango/Services/RegistryManager/RegistryManager.cs
+++ b/src/Pango/Services/RegistryManager/RegistryManager.cs
@@ -7,6 +7,9 @@ namespace Pango.Services.RegistryManager;
 
 public class RegistryManager() : IRegistryManager
 {
+    public const string PackFileExtension = ".br"; // Brotli
+    public const string RazorFileExtension = ".razor"; // Brotli
+
     public Result<ComponentMetadata, IRegistryError> CreateComponentMetadata(
         CreateComponentMetadataInput metadataInput
     )
@@ -28,11 +31,13 @@ public class RegistryManager() : IRegistryManager
             .Filter(dir =>
                 dir.Name == Path.GetFileNameWithoutExtension(metadataInput.LocalComponentPath)
             )
-            .Map(dir => dir.EnumerateFiles("*.razor*"))
+            .Map(dir => dir.EnumerateFiles($"*{RazorFileExtension}*"))
             .Filter(files => files.Any())
             .OkOr<IRegistryError>(new InvalidComponentPathError())
             .AndThen(files =>
-                ResolveComponent(files.First(f => f.Extension.StartsWith(".razor")).FullName)
+                ResolveComponent(
+                        files.First(f => f.Extension.StartsWith(RazorFileExtension)).FullName
+                    )
                     .Map(component =>
                         component with
                         {
@@ -50,7 +55,7 @@ public class RegistryManager() : IRegistryManager
             .TryFrom(() => new FileInfo(path))
             .Ok()
             .Filter(file => file.Exists)
-            .Filter(file => file.Extension == ".razor")
+            .Filter(file => file.Extension == RazorFileExtension)
             .Map(file => new ComponentMetadata(
                 Name: ResolveComponentName(file),
                 Source: ResolveComponentSource(file),
@@ -73,7 +78,10 @@ public class RegistryManager() : IRegistryManager
         {
             // TODO: Consider using StringBuilder to improve performance
             var originalFileExtension = Path.GetExtension(fileName);
-            var outputFileName = Path.ChangeExtension(fileName, $"{originalFileExtension}.br");
+            var outputFileName = Path.ChangeExtension(
+                fileName,
+                originalFileExtension + PackFileExtension
+            );
             var ouputDir = Path.Combine(packInput.OutputPath, packInput.Metadata.Source);
 
             // Ensures ouput dir exists

--- a/src/Pango/Services/RegistryManager/RegistryManager.cs
+++ b/src/Pango/Services/RegistryManager/RegistryManager.cs
@@ -1,3 +1,4 @@
+using System.IO.Compression;
 using Pango.Abstractions;
 using Pango.Extensions;
 using Pango.Types;
@@ -62,4 +63,37 @@ public class RegistryManager() : IRegistryManager
 
     protected static string ResolveComponentSource(FileInfo componentFile) =>
         componentFile.Name.Replace(componentFile.Extension, string.Empty);
+
+    public async Task<Result<ComponentMetadata, IRegistryError>> PackComponent(
+        PackComponentInput packInput
+    )
+    {
+        // TODO: Maybe use AsyncEnumerable to yield compressed files
+        var toPackTasks = packInput.Metadata.Files.Select(async fileName =>
+        {
+            // TODO: Consider using StringBuilder to improve performance
+            var originalFileExtension = Path.GetExtension(fileName);
+            var outputFileName = Path.ChangeExtension(fileName, $"{originalFileExtension}.br");
+            var ouputDir = Path.Combine(packInput.OutputPath, packInput.Metadata.Source);
+
+            // Ensures ouput dir exists
+            Directory.CreateDirectory(ouputDir);
+
+            using var inputFileStream = File.OpenRead(
+                Path.Combine(packInput.InputBasePath, fileName)
+            );
+            using var outputFileStream = File.Create(
+                Path.Combine(packInput.OutputPath, outputFileName)
+            );
+            using var compressor = new BrotliStream(outputFileStream, CompressionLevel.Optimal);
+            await inputFileStream.CopyToAsync(compressor);
+
+            return outputFileName;
+        });
+
+        return packInput.Metadata with
+        {
+            Files = await Task.WhenAll(toPackTasks),
+        };
+    }
 }

--- a/src/Pango/Services/RegistryManager/RegistryManager.cs
+++ b/src/Pango/Services/RegistryManager/RegistryManager.cs
@@ -41,10 +41,7 @@ public class RegistryManager() : IRegistryManager
                     .Map(component =>
                         component with
                         {
-                            Files =
-                            [
-                                .. files.Select(f => Path.Join(component.Source, f.Name)).Reverse(),
-                            ],
+                            Files = [.. files.Select(f => f.Name).Reverse()],
                         }
                     )
             );
@@ -87,11 +84,16 @@ public class RegistryManager() : IRegistryManager
             // Ensures ouput dir exists
             Directory.CreateDirectory(ouputDir);
 
+            var inputFilePath =
+                packInput.Metadata.Files.Length > 1
+                    ? Path.Combine(packInput.Metadata.Source, fileName)
+                    : fileName;
+
             using var inputFileStream = File.OpenRead(
-                Path.Combine(packInput.InputBasePath, fileName)
+                Path.Combine(packInput.InputBasePath, inputFilePath)
             );
             using var outputFileStream = File.Create(
-                Path.Combine(packInput.OutputPath, outputFileName)
+                Path.Combine(packInput.OutputPath, ouputDir, outputFileName)
             );
             using var compressor = new BrotliStream(outputFileStream, CompressionLevel.Optimal);
             await inputFileStream.CopyToAsync(compressor);

--- a/src/Pango/Services/RegistryManager/RegistryManager.cs
+++ b/src/Pango/Services/RegistryManager/RegistryManager.cs
@@ -4,36 +4,49 @@ using Pango.Types;
 
 namespace Pango.Services.RegistryManager;
 
-public class RegistryManager(RegistryOptions options) : IRegistryManager
+public class RegistryManager() : IRegistryManager
 {
-    public Result<ComponentMetadata, IRegistryError> CreateComponentMetadata(CreateComponentMetadataInput metadataInput)
+    public Result<ComponentMetadata, IRegistryError> CreateComponentMetadata(
+        CreateComponentMetadataInput metadataInput
+    )
     {
         var isComponentPath = Path.HasExtension(metadataInput.LocalComponentPath);
 
         if (isComponentPath)
             return ResolveComponent(metadataInput.LocalComponentPath);
 
-        var componentFolder = Result.TryFrom(() => new DirectoryInfo(metadataInput.LocalComponentPath));
+        var componentFolder = Result.TryFrom(
+            () => new DirectoryInfo(metadataInput.LocalComponentPath)
+        );
         if (componentFolder.IsErr())
             return new InvalidComponentPathError();
 
-        return componentFolder.Ok()
+        return componentFolder
+            .Ok()
             .Filter(dir => dir.Exists)
-            .Filter(dir => dir.Name == Path.GetFileNameWithoutExtension(metadataInput.LocalComponentPath))
+            .Filter(dir =>
+                dir.Name == Path.GetFileNameWithoutExtension(metadataInput.LocalComponentPath)
+            )
             .Map(dir => dir.EnumerateFiles("*.razor*"))
             .Filter(files => files.Any())
             .OkOr<IRegistryError>(new InvalidComponentPathError())
             .AndThen(files =>
                 ResolveComponent(files.First(f => f.Extension.StartsWith(".razor")).FullName)
-                .Map(component => component with
-                {
-                    Files = files.Select(f => f.Name).ToArray()
-                })
+                    .Map(component =>
+                        component with
+                        {
+                            Files =
+                            [
+                                .. files.Select(f => Path.Join(component.Source, f.Name)).Reverse(),
+                            ],
+                        }
+                    )
             );
     }
 
-    protected Result<ComponentMetadata, IRegistryError> ResolveComponent(string path)
-        => Result.TryFrom(() => new FileInfo(path))
+    protected static Result<ComponentMetadata, IRegistryError> ResolveComponent(string path) =>
+        Result
+            .TryFrom(() => new FileInfo(path))
             .Ok()
             .Filter(file => file.Exists)
             .Filter(file => file.Extension == ".razor")
@@ -44,14 +57,9 @@ public class RegistryManager(RegistryOptions options) : IRegistryManager
             ))
             .OkOr<IRegistryError>(new InvalidComponentPathError());
 
-    protected static string ResolveComponentName(FileInfo componentFile)
-        => componentFile.Name
-            .Replace(componentFile.Extension, string.Empty)
-            .ToKebabCase();
+    protected static string ResolveComponentName(FileInfo componentFile) =>
+        componentFile.Name.Replace(componentFile.Extension, string.Empty).ToKebabCase();
 
-    protected string ResolveComponentSource(FileInfo componentFile)
-        => Path.Combine(
-            options.RegistryBaseUri.ToString(),
-            componentFile.Name.Replace(componentFile.Extension, string.Empty)
-        );
+    protected static string ResolveComponentSource(FileInfo componentFile) =>
+        componentFile.Name.Replace(componentFile.Extension, string.Empty);
 }

--- a/src/Pango/Services/RegistryManager/RegistryOptions.cs
+++ b/src/Pango/Services/RegistryManager/RegistryOptions.cs
@@ -1,5 +1,0 @@
-namespace Pango.Services.RegistryManager;
-
-public record struct RegistryOptions(
-    Uri RegistryBaseUri
-);

--- a/src/Pango/Types/Component.cs
+++ b/src/Pango/Types/Component.cs
@@ -1,8 +1,10 @@
+using System.IO.Compression;
 using System.Net;
+using System.Text;
 using Pango.Abstractions;
 using Pango.Abstractions.ErrorKinds;
-using Pango.Types;
 using Pango.Extensions;
+using Pango.Types;
 
 namespace Pango.Services.RegistryClient;
 
@@ -10,20 +12,17 @@ public interface IComponentError;
 
 public interface IComponentState;
 
-
 public record struct Resolved : IComponentState;
 
 public record struct Streaming(Stream FileStream, string FileName) : IComponentState;
 
 public record struct Downloaded(string Filepath) : IComponentState;
 
-public record struct Component<TState>(
-    ComponentMetadata Metadata,
-    TState State
-)
+public record struct Component<TState>(ComponentMetadata Metadata, TState State)
     where TState : IComponentState, new()
 {
-    public Component(ComponentMetadata Metadata) : this(Metadata, new()) { }
+    public Component(ComponentMetadata Metadata)
+        : this(Metadata, new()) { }
 }
 
 public record struct ComponentStreamLine(string Line)
@@ -32,17 +31,17 @@ public record struct ComponentStreamLine(string Line)
 
     const int NotFoundIndex = -1;
 
-    readonly Option<int> NamespaceWordIndex => Option.From(Line)
-        .Filter(line => namespacePatterns.Any(pattern => line.TrimStart().StartsWith(pattern)))
-        .Map(line => line.IndexOf("namespace"))
-        .DiscardIf(idx => idx == NotFoundIndex);
+    readonly Option<int> NamespaceWordIndex =>
+        Option
+            .From(Line)
+            .Filter(line => namespacePatterns.Any(pattern => line.TrimStart().StartsWith(pattern)))
+            .Map(line => line.IndexOf("namespace"))
+            .DiscardIf(idx => idx == NotFoundIndex);
 
     public readonly bool IsNamespaceLine => NamespaceWordIndex.IsSome();
 
-    ComponentStreamLine ApplyLineEnding(string fileExtension)
-        => fileExtension.EndsWith(".razor")
-            ? this
-            : this with { Line = Line + ';' };
+    ComponentStreamLine ApplyLineEnding(string fileExtension) =>
+        fileExtension.EndsWith(".razor") ? this : this with { Line = Line + ';' };
 
     public readonly ComponentStreamLine ApplyNamespace(string @namespace, string fileExtension)
     {
@@ -54,7 +53,7 @@ public record struct ComponentStreamLine(string Line)
             Line = Line.Replace(
                 oldValue: Line[namespaceIdx.Value..],
                 newValue: $"namespace {@namespace}"
-            )
+            ),
         };
 
         return updatedNamespaceLine.ApplyLineEnding(fileExtension);
@@ -62,14 +61,12 @@ public record struct ComponentStreamLine(string Line)
 
     public static implicit operator string(ComponentStreamLine streamLine) => streamLine.Line;
 
-    public static Option<ComponentStreamLine> From(string? line)
-        => Option.From(line)
-            .Map(line => new ComponentStreamLine(line));
+    public static Option<ComponentStreamLine> From(string? line) =>
+        Option.From(line).Map(line => new ComponentStreamLine(line));
 }
 
 public static class Component
 {
-
     /// <summary>
     /// Resolves a component metadata by fetching the registry
     /// </summary>
@@ -79,19 +76,19 @@ public static class Component
     /// <returns>The resolved component</returns>
     public static async Task<Result<Component<Resolved>, IError>> ResolveFrom(
         HttpClient httpClient,
-        string remoteUri,
         string name
     )
     {
         var componentMetadataName = Path.ChangeExtension(name, "json");
-        var componentMetadataUrl = Path.Combine(remoteUri, componentMetadataName);
 
-        var response = await httpClient.GetAsync(componentMetadataUrl);
+        var response = await httpClient.GetAsync(componentMetadataName);
 
-        var result = await response.ToResult()
-            .MapErr(err => err.HttpResponse.StatusCode == HttpStatusCode.NotFound
-                ? new NotFoundError().WithMessage("Component could not be found or not exists!")
-                : err.Error
+        var result = await response
+            .ToResult()
+            .MapErr(err =>
+                err.HttpResponse.StatusCode == HttpStatusCode.NotFound
+                    ? new NotFoundError().WithMessage("Component could not be found or not exists!")
+                    : err.Error
             )
             .AndThen(HttpClientExtensions.ReadFromJsonAsync<ComponentMetadata>);
 
@@ -112,8 +109,10 @@ public static class ResolvedComponent
         HttpClient httpClient
     )
     {
-        var GetFileUrl = (string file) => Path.Combine(component.Metadata.Source, file);
-        var GetFileStream = (string fileUrl) => Result.TryFrom(() => httpClient.GetStreamAsync(fileUrl));
+        string GetFileUrl(string file) => Path.Combine(component.Metadata.Source, file);
+
+        Task<Result<Stream, Exception>> GetFileStream(string fileUrl) =>
+            Result.TryFrom(() => httpClient.GetStreamAsync(fileUrl));
 
         foreach (var filename in component.Metadata.Files)
         {
@@ -124,10 +123,7 @@ public static class ResolvedComponent
                 .MapErr(ExceptionError.From)
                 .Map(stream => new Component<Streaming>(
                     Metadata: component.Metadata,
-                    State: new(
-                        FileStream: stream,
-                        FileName: filename
-                    )
+                    State: new(FileStream: stream, FileName: filename)
                 ));
         }
     }
@@ -160,15 +156,21 @@ public static class StreamingComponent
 
         filepath.Directory?.Create();
 
+        var outputFilePath = filepath.FullName.EndsWith(".br")
+            ? new StringBuilder(filepath.FullName)
+                .Remove(filepath.FullName.Length - 3, 3) // removes ".br" Brotli exentsion
+                .ToString()
+            : filepath.FullName;
+
         var writeResult = await WriteComponentStream(
             stream: component.State.FileStream,
-            filepath: filepath.FullName,
+            filepath: outputFilePath,
             @namespace: localBaseNamespace
         );
 
         return writeResult.Map(_ => new Component<Downloaded>(
             Metadata: component.Metadata,
-            State: new(Filepath: filepath.FullName)
+            State: new(Filepath: outputFilePath)
         ));
     }
 
@@ -179,19 +181,26 @@ public static class StreamingComponent
     /// <param name="filepath"></param>
     /// <param name="namespace"></param>
     /// <returns></returns>
-    public static async Task<Result<IOk, IError>> WriteComponentStream(Stream stream, string filepath, string @namespace)
+    public static async Task<Result<IOk, IError>> WriteComponentStream(
+        Stream stream,
+        string filepath,
+        string @namespace
+    )
     {
-        using var reader = new StreamReader(stream);
+        using var contentStream = new MemoryStream();
+        using var decompressor = new BrotliStream(stream, CompressionMode.Decompress);
+        await decompressor.CopyToAsync(contentStream);
+        contentStream.Seek(0, SeekOrigin.Begin);
+
+        using var reader = new StreamReader(contentStream);
         using var writer = new StreamWriter(filepath);
 
-        while (ComponentStreamLine.From(await reader.ReadLineAsync()) is Some<ComponentStreamLine> line)
+        while (
+            ComponentStreamLine.From(await reader.ReadLineAsync()) is Some<ComponentStreamLine> line
+        )
         {
             await writer.WriteLineAsync(
-                value: line.Value
-                    .ApplyNamespace(
-                        @namespace: @namespace,
-                        fileExtension: filepath
-                    )
+                value: line.Value.ApplyNamespace(@namespace: @namespace, fileExtension: filepath)
             );
         }
 

--- a/tests/Pango.Tests/Pango.Tests.csproj
+++ b/tests/Pango.Tests/Pango.Tests.csproj
@@ -7,6 +7,7 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Pango.Tests/Pango.Tests.csproj
+++ b/tests/Pango.Tests/Pango.Tests.csproj
@@ -24,7 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Spectre.Console.Testing" Version="0.48.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Pango\Pango.csproj" />
+    <ProjectReference Include="..\..\src\Pango.Tool\Pango.Tool.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Pango.Tests/Services/RegistryManager/CreateMetadataTests.cs
+++ b/tests/Pango.Tests/Services/RegistryManager/CreateMetadataTests.cs
@@ -13,10 +13,13 @@ public partial class RegistryManagerTests
     [InlineData(["hello-world", "HelloWorld.razor", 1])] // Single file component
     public void ShouldCreateMetadataForValidComponent(string name, string component, int fileCount)
     {
-        var registryUri = new Uri("https://test.pango/UI");
-        var manager = new RegistryManager(new(registryUri));
+        var manager = new RegistryManager();
 
-        var componentPath = Path.Combine(Directory.GetCurrentDirectory(), componentsFolder, component);
+        var componentPath = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            componentsFolder,
+            component
+        );
 
         var componentMetadata = manager.CreateComponentMetadata(new(componentPath));
 
@@ -25,18 +28,12 @@ public partial class RegistryManagerTests
         var metadata = componentMetadata.Expect();
         Assert.IsType<ComponentMetadata>(metadata);
 
-        Assert.Equal(
-            expected: name,
-            actual: metadata.Name
-        );
+        Assert.Equal(expected: name, actual: metadata.Name);
         Assert.EndsWith(
             expectedEndString: component.Replace(".razor", string.Empty),
             actualString: metadata.Source
         );
-        Assert.Equal(
-            expected: fileCount,
-            actual: metadata.Files.Length
-        );
+        Assert.Equal(expected: fileCount, actual: metadata.Files.Length);
     }
 
     [Theory]
@@ -47,10 +44,13 @@ public partial class RegistryManagerTests
     [InlineData(".")]
     public void ShouldErrorWhenInvalidComponent(string component)
     {
-        var registryUri = new Uri("https://test.pango/UI");
-        var manager = new RegistryManager(new(registryUri));
+        var manager = new RegistryManager();
 
-        var componentPath = Path.Combine(Directory.GetCurrentDirectory(), componentsFolder, component);
+        var componentPath = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            componentsFolder,
+            component
+        );
 
         var componentMetadata = manager.CreateComponentMetadata(new(componentPath));
 

--- a/tests/Pango.Tests/Services/RegistryManager/CreateMetadataTests.cs
+++ b/tests/Pango.Tests/Services/RegistryManager/CreateMetadataTests.cs
@@ -4,10 +4,8 @@ using Pango.Types;
 
 namespace Pango.Tests;
 
-public partial class RegistryManagerTests
+public class CreateMetadataTests : RegistryManagerTests
 {
-    const string componentsFolder = "Mock/Files";
-
     [Theory]
     [InlineData(["button", "Button", 4])] // Folder component
     [InlineData(["hello-world", "HelloWorld.razor", 1])] // Single file component
@@ -17,7 +15,7 @@ public partial class RegistryManagerTests
 
         var componentPath = Path.Combine(
             Directory.GetCurrentDirectory(),
-            componentsFolder,
+            ComponentsFolder,
             component
         );
 
@@ -48,7 +46,7 @@ public partial class RegistryManagerTests
 
         var componentPath = Path.Combine(
             Directory.GetCurrentDirectory(),
-            componentsFolder,
+            ComponentsFolder,
             component
         );
 

--- a/tests/Pango.Tests/Services/RegistryManager/PackComponentTests.cs
+++ b/tests/Pango.Tests/Services/RegistryManager/PackComponentTests.cs
@@ -1,5 +1,4 @@
 using System.IO.Compression;
-using System.Text.Json;
 using Pango.Abstractions;
 using Pango.Services.RegistryManager;
 using Pango.Types;
@@ -44,17 +43,25 @@ public class PackComponentTests : RegistryManagerTests, IDisposable
 
         foreach (var fileName in packedMetadata.Files)
         {
-            var filePath = Path.Combine(OutputPath, fileName);
-            var packedFile = new FileInfo(filePath);
+            var packedFile = new FileInfo(
+                Path.Combine(OutputPath, packedMetadata.Source, fileName)
+            );
 
             Assert.NotNull(packedFile);
             Assert.True(packedFile.Exists);
             Assert.Equal(RegistryManager.PackFileExtension, packedFile.Extension);
 
+            // Components can be folder or single
+            var originalFileName =
+                packedMetadata.Files.Length > 1
+                    ? Path.Combine(packedMetadata.Source, fileName)
+                    : fileName;
+
             var originalFilePath = Path.Combine(
                 ComponentsPath,
-                fileName[..^RegistryManager.PackFileExtension.Length]
+                originalFileName[..^RegistryManager.PackFileExtension.Length] // removes the ".br" extension
             );
+
             var originalFileBytes = await File.ReadAllBytesAsync(originalFilePath);
             var packedFileBytes = await File.ReadAllBytesAsync(packedFile.FullName);
 

--- a/tests/Pango.Tests/Services/RegistryManager/PackComponentTests.cs
+++ b/tests/Pango.Tests/Services/RegistryManager/PackComponentTests.cs
@@ -1,0 +1,73 @@
+using System.IO.Compression;
+using System.Text.Json;
+using Pango.Abstractions;
+using Pango.Services.RegistryManager;
+using Pango.Types;
+
+namespace Pango.Tests;
+
+public class PackComponentTests : RegistryManagerTests, IDisposable
+{
+    static string ComponentsPath => Path.Combine(Directory.GetCurrentDirectory(), ComponentsFolder);
+    static string OutputPath => Path.Combine(Directory.GetCurrentDirectory(), OutputFolder);
+
+    public void Dispose()
+    {
+        var outputFolder = new DirectoryInfo(OutputPath);
+        outputFolder.Delete(true);
+    }
+
+    [Theory]
+    [InlineData(["Button"])] // Folder component
+    [InlineData(["HelloWorld.razor"])] // Single file component
+    public async Task ShouldPackComponent(string component)
+    {
+        var manager = new RegistryManager();
+
+        var componentPath = Path.Combine(ComponentsPath, component);
+
+        var metadata = manager
+            .CreateComponentMetadata(new CreateComponentMetadataInput(componentPath))
+            .Expect();
+
+        var packResult = await manager.PackComponent(
+            new PackComponentInput(metadata, ComponentsFolder, OutputPath)
+        );
+        Assert.True(packResult.IsOk());
+
+        var packedMetadata = packResult.Expect();
+        Assert.IsType<ComponentMetadata>(packedMetadata);
+
+        Assert.Equal(expected: packedMetadata.Name, actual: metadata.Name);
+        Assert.Equal(expected: packedMetadata.Source, actual: metadata.Source);
+        Assert.Equal(expected: packedMetadata.Files.Length, actual: metadata.Files.Length);
+
+        foreach (var fileName in packedMetadata.Files)
+        {
+            var filePath = Path.Combine(OutputPath, fileName);
+            var packedFile = new FileInfo(filePath);
+
+            Assert.NotNull(packedFile);
+            Assert.True(packedFile.Exists);
+            Assert.Equal(RegistryManager.PackFileExtension, packedFile.Extension);
+
+            var originalFilePath = Path.Combine(
+                ComponentsPath,
+                fileName[..^RegistryManager.PackFileExtension.Length]
+            );
+            var originalFileBytes = await File.ReadAllBytesAsync(originalFilePath);
+            var packedFileBytes = await File.ReadAllBytesAsync(packedFile.FullName);
+
+            var output = new Span<byte>(originalFileBytes);
+            var hasDecompressed = BrotliDecoder.TryDecompress(
+                packedFileBytes,
+                output,
+                out var bytesWritten
+            );
+
+            Assert.True(hasDecompressed);
+            Assert.Equal(originalFileBytes.Length, bytesWritten);
+            Assert.True(originalFileBytes.AsSpan().SequenceEqual(output));
+        }
+    }
+}

--- a/tests/Pango.Tests/Services/RegistryManager/RegistryManagerTests.cs
+++ b/tests/Pango.Tests/Services/RegistryManager/RegistryManagerTests.cs
@@ -1,0 +1,7 @@
+namespace Pango.Tests;
+
+public class RegistryManagerTests
+{
+    public const string ComponentsFolder = "Mock/Files";
+    public const string OutputFolder = "publish";
+}

--- a/tests/Pango.Tests/Tool/Commands/ComponentRegisterCreationTest.cs
+++ b/tests/Pango.Tests/Tool/Commands/ComponentRegisterCreationTest.cs
@@ -1,0 +1,54 @@
+using System.Text.Json;
+using Pango.Abstractions;
+using Pango.Commands;
+using Pango.Services.RegistryManager;
+using Pango.Types;
+using Spectre.Console.Testing;
+
+namespace Pango.Tests;
+
+public class ComponentRegisterCreationTest : IDisposable
+{
+    public string ComponentsPath => Path.Combine(Directory.GetCurrentDirectory(), "Mock/Files");
+    public string OutputPath => Path.Combine(Directory.GetCurrentDirectory(), "publish-cmd");
+
+    public void Dispose()
+    {
+        var outputFolder = new DirectoryInfo(OutputPath);
+        outputFolder.Delete(true);
+    }
+
+    [Theory]
+    [InlineData(["Button", "button.json", "Button", 4])] // Folder component
+    [InlineData(["HelloWorld.razor", "hello-world.json", "HelloWorld", 1])] // Single file component
+    public void ShouldCreateRegisterForValidComponents(
+        string componentInput,
+        string metadataFileName,
+        string outputFolderName,
+        int generatedFilesCount
+    )
+    {
+        var app = new CommandAppTester();
+        app.SetDefaultCommand<ComponentRegisterCreation>();
+
+        var componentPath = Path.Combine(ComponentsPath, componentInput);
+        var result = app.Run(componentPath, "-o", OutputPath);
+        Assert.Equal(0, result.ExitCode);
+
+        var outputMetadataFilePath = Path.Combine(OutputPath, metadataFileName);
+        var metadata = JsonSerializer.Deserialize<ComponentMetadata>(
+            File.ReadAllText(outputMetadataFilePath),
+            options: new(JsonSerializerDefaults.Web)
+        );
+        Assert.IsType<ComponentMetadata>(metadata);
+
+        var expectedComponentName = Path.GetFileNameWithoutExtension(metadataFileName);
+        Assert.Equal(expectedComponentName, metadata.Name);
+        Assert.Equal(outputFolderName, metadata.Source);
+        Assert.Equal(generatedFilesCount, metadata.Files.Length);
+
+        var outputDir = new DirectoryInfo(Path.Combine(OutputPath, outputFolderName));
+        Assert.True(outputDir.Exists);
+        Assert.Equal(generatedFilesCount, outputDir.EnumerateFiles().Count());
+    }
+}


### PR DESCRIPTION
This PR adds support to brotli compression during **registry creation** it allows components to be packed as static files within registry endpoints. So a `registry-url` is no more required, since all files will use relative path discovering.