### PR TITLE
fix: multiple component at same folder

### DIFF
--- a/Pango.sln
+++ b/Pango.sln
@@ -7,8 +7,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{9030593D-09D
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pango", "src\Pango\Pango.csproj", "{E819B3C7-3564-4387-9EE0-3BCD599ABCA5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pango.Components", "src\Pango.Components\Pango.Components.csproj", "{BA58E7F9-05F5-414F-990B-919D153FCD8B}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pango.Tool", "src\Pango.Tool\Pango.Tool.csproj", "{C014F82B-96DA-440C-9113-BDA6AE4D78F8}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{F2F3DBFB-BAF3-4C3D-97B9-E6B328E3AB09}"
@@ -20,18 +18,11 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E819B3C7-3564-4387-9EE0-3BCD599ABCA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E819B3C7-3564-4387-9EE0-3BCD599ABCA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E819B3C7-3564-4387-9EE0-3BCD599ABCA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E819B3C7-3564-4387-9EE0-3BCD599ABCA5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BA58E7F9-05F5-414F-990B-919D153FCD8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BA58E7F9-05F5-414F-990B-919D153FCD8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BA58E7F9-05F5-414F-990B-919D153FCD8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BA58E7F9-05F5-414F-990B-919D153FCD8B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C014F82B-96DA-440C-9113-BDA6AE4D78F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C014F82B-96DA-440C-9113-BDA6AE4D78F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C014F82B-96DA-440C-9113-BDA6AE4D78F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -41,9 +32,11 @@ Global
 		{9FD10931-C2FE-4F6E-AB7D-01D28E672BEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9FD10931-C2FE-4F6E-AB7D-01D28E672BEE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{E819B3C7-3564-4387-9EE0-3BCD599ABCA5} = {9030593D-09DB-402D-9D8C-7C10BA7C5AE9}
-		{BA58E7F9-05F5-414F-990B-919D153FCD8B} = {9030593D-09DB-402D-9D8C-7C10BA7C5AE9}
 		{C014F82B-96DA-440C-9113-BDA6AE4D78F8} = {9030593D-09DB-402D-9D8C-7C10BA7C5AE9}
 		{9FD10931-C2FE-4F6E-AB7D-01D28E672BEE} = {F2F3DBFB-BAF3-4C3D-97B9-E6B328E3AB09}
 	EndGlobalSection

--- a/src/Pango/Services/RegistryManager/RegistryManager.cs
+++ b/src/Pango/Services/RegistryManager/RegistryManager.cs
@@ -31,20 +31,14 @@ public class RegistryManager() : IRegistryManager
             .Filter(dir =>
                 dir.Name == Path.GetFileNameWithoutExtension(metadataInput.LocalComponentPath)
             )
-            .Map(dir => dir.EnumerateFiles($"*{RazorFileExtension}*"))
-            .Filter(files => files.Any())
+            .Map(dir => new { Folder = dir, Files = dir.EnumerateFiles($"*{RazorFileExtension}*") })
+            .Filter(component => component.Files.Any())
             .OkOr<IRegistryError>(new InvalidComponentPathError())
-            .AndThen(files =>
-                ResolveComponent(
-                        files.First(f => f.Extension.StartsWith(RazorFileExtension)).FullName
-                    )
-                    .Map(component =>
-                        component with
-                        {
-                            Files = [.. files.Select(f => f.Name).Reverse()],
-                        }
-                    )
-            );
+            .Map(component => new ComponentMetadata(
+                Name: ResolveComponentName(component.Folder.Name),
+                Source: ResolveComponentSource(component.Folder.Name),
+                Files: [.. component.Files.Select(f => f.Name).Reverse()]
+            ));
     }
 
     protected static Result<ComponentMetadata, IRegistryError> ResolveComponent(string path) =>
@@ -54,17 +48,17 @@ public class RegistryManager() : IRegistryManager
             .Filter(file => file.Exists)
             .Filter(file => file.Extension == RazorFileExtension)
             .Map(file => new ComponentMetadata(
-                Name: ResolveComponentName(file),
-                Source: ResolveComponentSource(file),
+                Name: ResolveComponentName(file.Name),
+                Source: ResolveComponentSource(file.Name),
                 Files: [file.Name]
             ))
             .OkOr<IRegistryError>(new InvalidComponentPathError());
 
-    protected static string ResolveComponentName(FileInfo componentFile) =>
-        componentFile.Name.Replace(componentFile.Extension, string.Empty).ToKebabCase();
+    protected static string ResolveComponentName(string componentPath) =>
+        ResolveComponentSource(componentPath).ToKebabCase();
 
-    protected static string ResolveComponentSource(FileInfo componentFile) =>
-        componentFile.Name.Replace(componentFile.Extension, string.Empty);
+    protected static string ResolveComponentSource(string componentPath) =>
+        Path.GetFileNameWithoutExtension(componentPath);
 
     public async Task<Result<ComponentMetadata, IRegistryError>> PackComponent(
         PackComponentInput packInput

--- a/tests/Pango.Tests/Mock/Files/Button/ButtonChild.razor
+++ b/tests/Pango.Tests/Mock/Files/Button/ButtonChild.razor
@@ -1,0 +1,3 @@
+@namespace Pango.Tests.Mock.Files
+
+<button>Click me 2</button>

--- a/tests/Pango.Tests/Mock/Files/DataTable/DataTable.razor
+++ b/tests/Pango.Tests/Mock/Files/DataTable/DataTable.razor
@@ -1,0 +1,3 @@
+@namespace Pango.Tests.Mock.Files
+
+<table></table>

--- a/tests/Pango.Tests/Mock/Files/DataTable/DataTablePagination.razor
+++ b/tests/Pango.Tests/Mock/Files/DataTable/DataTablePagination.razor
@@ -1,0 +1,3 @@
+@namespace Pango.Tests.Mock.Files
+
+<div></div>

--- a/tests/Pango.Tests/Services/RegistryManager/CreateMetadataTests.cs
+++ b/tests/Pango.Tests/Services/RegistryManager/CreateMetadataTests.cs
@@ -7,7 +7,8 @@ namespace Pango.Tests;
 public class CreateMetadataTests : RegistryManagerTests
 {
     [Theory]
-    [InlineData(["button", "Button", 4])] // Folder component
+    [InlineData(["button", "Button", 5])] // Folder component
+    [InlineData(["data-table", "DataTable", 2])] // Folder component
     [InlineData(["hello-world", "HelloWorld.razor", 1])] // Single file component
     public void ShouldCreateMetadataForValidComponent(string name, string component, int fileCount)
     {

--- a/tests/Pango.Tests/Services/RegistryManager/PackComponentTests.cs
+++ b/tests/Pango.Tests/Services/RegistryManager/PackComponentTests.cs
@@ -18,6 +18,7 @@ public class PackComponentTests : RegistryManagerTests, IDisposable
 
     [Theory]
     [InlineData(["Button"])] // Folder component
+    [InlineData(["DataTable"])] // Folder component
     [InlineData(["HelloWorld.razor"])] // Single file component
     public async Task ShouldPackComponent(string component)
     {

--- a/tests/Pango.Tests/Tool/Commands/ComponentRegisterCreationTest.cs
+++ b/tests/Pango.Tests/Tool/Commands/ComponentRegisterCreationTest.cs
@@ -10,7 +10,7 @@ namespace Pango.Tests;
 public class ComponentRegisterCreationTest : IDisposable
 {
     public string ComponentsPath => Path.Combine(Directory.GetCurrentDirectory(), "Mock/Files");
-    public string OutputPath => Path.Combine(Directory.GetCurrentDirectory(), "publish-cmd");
+    public string OutputPath => Path.Combine(Directory.GetCurrentDirectory(), "publish-tool");
 
     public void Dispose()
     {
@@ -19,7 +19,7 @@ public class ComponentRegisterCreationTest : IDisposable
     }
 
     [Theory]
-    [InlineData(["Button", "button.json", "Button", 4])] // Folder component
+    [InlineData(["Button", "button.json", "Button", 5])] // Folder component
     [InlineData(["HelloWorld.razor", "hello-world.json", "HelloWorld", 1])] // Single file component
     public void ShouldCreateRegisterForValidComponents(
         string componentInput,


### PR DESCRIPTION
This PR fix the name resolution strategy to use the component folder, its allows that a folder component to have files with different names. This way child components can be grouped together.